### PR TITLE
Revert "Merge pull request #26 from Wenzel/kvm_support"

### DIFF
--- a/vmidbg/__main__.py
+++ b/vmidbg/__main__.py
@@ -7,11 +7,10 @@ Usage:
   vmidbg.py (-h | --help)
 
 Options:
-  -d --debug                            Enable debugging
-  -a ADDR, --address=<ADDR>             Server address to listen on [default: 127.0.0.1]
-  -k SOCKET --kvmi-socket SOCKET        If hypervisor is KVM, specify the KVMi socket
-  -h --help                             Show this screen.
-  --version                             Show version.
+  -d --debug                    Enable debugging
+  -a ADDR, --address=<ADDR>     Server address to listen on [default: 127.0.0.1]
+  -h --help                     Show this screen.
+  --version                     Show version.
 
 """
 
@@ -26,7 +25,6 @@ def main():
     args = docopt(__doc__)
     debug = args['--debug']
     address = args['--address']
-    kvmi_socket = args['--kvmi-socket']
     port = int(args['<port>'])
     vm_name = args['<vm_name>']
     process = args['<process>']
@@ -36,7 +34,7 @@ def main():
         log_level = logging.DEBUG
     logging.basicConfig(level=log_level)
 
-    with GDBServer(address, port, stub_cls=LibVMIStub, stub_args=(vm_name, process, kvmi_socket)) as server:
+    with GDBServer(address, port, stub_cls=LibVMIStub, stub_args=(vm_name, process)) as server:
         server.listen()
 
 

--- a/vmidbg/libvmistub.py
+++ b/vmidbg/libvmistub.py
@@ -5,7 +5,7 @@ from functools import lru_cache
 from lxml import etree
 from binascii import hexlify, unhexlify
 
-from libvmi import Libvmi, INIT_DOMAINNAME, INIT_EVENTS, VMIOS, LibvmiError, X86Reg, VMIInitData
+from libvmi import Libvmi, INIT_DOMAINNAME, INIT_EVENTS, VMIOS, LibvmiError, X86Reg
 
 from .gdbstub import GDBStub, GDBPacket, GDBCmd, GDBSignal, PACKET_SIZE
 from .rawdebugcontext import RawDebugContext
@@ -17,11 +17,10 @@ SW_BREAKPOINT = b'\xcc'
 
 class LibVMIStub(GDBStub):
 
-    def __init__(self, conn, addr, vm_name, process, kvmi_socket=None):
+    def __init__(self, conn, addr, vm_name, process):
         super().__init__(conn, addr)
         self.vm_name = vm_name
         self.process = process
-        self.kvmi_socket = kvmi_socket
         self.cmd_to_handler = {
             GDBCmd.GEN_QUERY_GET: self.gen_query_get,
             GDBCmd.GEN_QUERY_SET: self.gen_query_set,
@@ -60,11 +59,7 @@ class LibVMIStub(GDBStub):
 
     def __enter__(self):
         # init LibVMI
-        init_data = None
-        if self.kvmi_socket:
-            init_data = {VMIInitData.KVMI_SOCKET: self.kvmi_socket}
-        self.vmi = Libvmi(self.vm_name, init_flags=INIT_DOMAINNAME | INIT_EVENTS,
-                          init_data=init_data, partial=True)
+        self.vmi = Libvmi(self.vm_name, init_flags=INIT_DOMAINNAME | INIT_EVENTS, partial=True)
         self.vmi.init_paging(flags=0)
         # catch every exception to force a clean exit with __exit__
         # where vmi.destroy() must be called


### PR DESCRIPTION
This reverts commit b1070063c9f6aa1b2ae63b2caf644ee71b5b7f15, reversing
changes made to 2f2656c824ca5b5a57d7f638ff784542206169f5.

The KVM support is not available in LibVMI upstream yet, so there is no point in supporting in pyvmidbg upstream.
cc @pwpwn 